### PR TITLE
refactor cryptorankings for venues count

### DIFF
--- a/client/src/actions/cryptosRankingActions.js
+++ b/client/src/actions/cryptosRankingActions.js
@@ -9,7 +9,7 @@ export function _loadCryptosRanking() {
 
   return dispatch => {
     dispatch(fetchCryptosBegin());
-    return fetch("/api/cryptosranking", cryptosRankingSettings)
+    return fetch("/api/cryptosranking_venues", cryptosRankingSettings)
       .then(res => res.json())
       .then(jsonCryptos => {
         dispatch(fetchCryptosSuccess(jsonCryptos));

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -8,7 +8,6 @@ CREATE TABLE crypto_metadata(
 	crypto_name VARCHAR(255) NOT NULL UNIQUE,
 	crypto_symbol VARCHAR(255) NOT NULL UNIQUE,
 	crypto_price DECIMAL(10, 4) NOT NULL,
-	venues_count INT NULL,
 	PRIMARY KEY (id)
 );
 

--- a/routes/cryptos_ranking.js
+++ b/routes/cryptos_ranking.js
@@ -24,32 +24,12 @@ var connection = mysql.createConnection({
   database: process.env.DB_DB
 });
 
-// api
-router.get('/api/cryptosranking', function(req, res) {
+router.get('/api/cryptosranking_venues', function(req, res) {
   connection.query(
-    'SELECT crypto_id, count(venue_id) as total FROM cryptos_venues GROUP BY crypto_id',
+    'SELECT crypto_id, crypto_name, crypto_symbol, crypto_logo, crypto_price, count(venue_id) as venues_count FROM cryptos_venues LEFT JOIN crypto_metadata ON cryptos_venues.crypto_id = crypto_metadata.id LEFT JOIN crypto_info ON crypto_metadata.crypto_name = crypto_info.crypto_metadata_name GROUP BY crypto_id ORDER by venues_count DESC',
     function(err, venues_count, fields) {
-      for (var i in venues_count) {
-        connection.query(
-          'UPDATE crypto_metadata SET ? WHERE ?',
-          [
-            { venues_count: venues_count[i].total },
-            { id: venues_count[i].crypto_id }
-          ],
-          function(err, res) {
-            if (err) {
-              console.log(err);
-            }
-          }
-        );
-      }
-
-      connection.query(
-        'SELECT * FROM crypto_metadata LEFT JOIN crypto_info ON crypto_metadata.crypto_name = crypto_info.crypto_metadata_name ORDER by venues_count DESC',
-        function(err, data, fields) {
-          res.json(data);
-        }
-      );
+      if(err) console.log(err);
+      res.json(venues_count);
     }
   );
 });


### PR DESCRIPTION
- change route name to /api/cryptosranking_venues
- Refactor the codes so we get the total venues accepted by cryptos from just one query
- remove venues count from crypto_metadata
